### PR TITLE
feat: allow template literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
         '@typescript-eslint/no-var-requires': 'off',
+        quotes: ['error', 'single', { allowTemplateLiterals: true }],
       },
     },
   ],


### PR DESCRIPTION
Reasoning behind my change here is mainly jest snapshots. In most projects I work on, there are inline snapshots.

Which typically looks like this:
```
`"hello world"`
```

I feel we should allow for this.

Would love to hear feedback!
