### PR TITLE
refactor!: Error when using explicit `any`

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
     curly: 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'warn',
     '@typescript-eslint/member-ordering': 'error',
-    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-unused-expressions': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',


### PR DESCRIPTION
Using `warn` communicate that it _can_ be used. We shouldn't ever use them without a good reason. Therefore I think it makes sense to error out when used without cause.

e.g. this example below shows what I think it makes more sense when they are needed.

```typescript
/* eslint-disable-next-line @typescript-eslint/no-explicit-any --
 * Here's a very long description about why this configuration is necessary
 * along with some additional information
**/
function helloWorld(thing: any) { ... }
```