### PR TITLE
feat!: improve esm rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ These are the available configs:
 - `@bjerk/eslint-config/base`
 - `@bjerk/eslint-config/import`
 - `@bjerk/eslint-config/typescript`
+- `@bjerk/eslint-config/esm`
 
 **Note**: The main `@bjerk/eslint-config` config includes all the others, but
 also `prettier` (and `eslint-config-prettier`).

--- a/base.js
+++ b/base.js
@@ -77,24 +77,6 @@ const eslintConfigBasic = {
     ],
 
     'eslint-comments/no-unused-disable': 'error',
-
-    /**
-     * Prefer using ESM over legacy CommonJS modules
-     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-module.md
-     */
-    'unicorn/prefer-module': 'error',
-
-    /**
-     * Prefer using the `node:` protocol when importing Node.js builtin modules
-     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md
-     */
-    'unicorn/prefer-node-protocol': 'error',
-
-    /**
-     * Prefer top-level await over top-level promises and async function calls
-     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-top-level-await.md
-     */
-    'unicorn/prefer-top-level-await': 'error',
   },
   overrides: [
     {

--- a/base.js
+++ b/base.js
@@ -77,6 +77,24 @@ const eslintConfigBasic = {
     ],
 
     'eslint-comments/no-unused-disable': 'error',
+
+    /**
+     * Prefer using ESM over legacy CommonJS modules
+     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-module.md
+     */
+    'unicorn/prefer-module': 'error',
+
+    /**
+     * Prefer using the `node:` protocol when importing Node.js builtin modules
+     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md
+     */
+    'unicorn/prefer-node-protocol': 'error',
+
+    /**
+     * Prefer top-level await over top-level promises and async function calls
+     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-top-level-await.md
+     */
+    'unicorn/prefer-top-level-await': 'error',
   },
   overrides: [
     {

--- a/esm.js
+++ b/esm.js
@@ -1,0 +1,33 @@
+require('@rushstack/eslint-patch/modern-module-resolution');
+
+/**
+ * @type {import('eslint').Linter.Config}
+ **/
+const eslintConfigBasic = {
+  plugins: ['unicorn', 'import'],
+  rules: {
+    /**
+     * Prefer using ESM over legacy CommonJS modules
+     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-module.md
+     */
+    'unicorn/prefer-module': 'error',
+
+    /**
+     * Prefer using the `node:` protocol when importing Node.js builtin modules
+     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md
+     */
+    'unicorn/prefer-node-protocol': 'error',
+
+    /**
+     * Prefer top-level await over top-level promises and async function calls
+     * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-top-level-await.md
+     */
+    'unicorn/prefer-top-level-await': 'error',
+
+    'import/extensions': ['error', 'always', { ignorePackages: true }],
+    'import/no-commonjs': 'error',
+  },
+};
+
+// eslint-disable-next-line no-undef
+module.exports = eslintConfigBasic;

--- a/esm.js
+++ b/esm.js
@@ -3,7 +3,7 @@ require('@rushstack/eslint-patch/modern-module-resolution');
 /**
  * @type {import('eslint').Linter.Config}
  **/
-const eslintConfigBasic = {
+const eslintConfigESM = {
   plugins: ['unicorn', 'import'],
   rules: {
     /**
@@ -30,4 +30,4 @@ const eslintConfigBasic = {
 };
 
 // eslint-disable-next-line no-undef
-module.exports = eslintConfigBasic;
+module.exports = eslintConfigESM;

--- a/import.js
+++ b/import.js
@@ -1,5 +1,8 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
+/**
+ * @type {import('eslint').Linter.Config}
+ **/
 const eslintConfigImport = {
   plugins: ['import'],
   rules: {
@@ -20,6 +23,14 @@ const eslintConfigImport = {
       'error',
       {
         ignoreDeclarationSort: true,
+      },
+    ],
+    'import/extensions': ['error', 'always', { ignorePackages: true }],
+    'import/no-commonjs': 'error',
+    'import/no-useless-path-segments': [
+      'error',
+      {
+        noUselessIndex: true,
       },
     ],
   },

--- a/import.js
+++ b/import.js
@@ -25,8 +25,6 @@ const eslintConfigImport = {
         ignoreDeclarationSort: true,
       },
     ],
-    'import/extensions': ['error', 'always', { ignorePackages: true }],
-    'import/no-commonjs': 'error',
     'import/no-useless-path-segments': [
       'error',
       {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 const eslintConfig = {
-  extends: ['./base', './typescript', './import', 'prettier'],
+  extends: ['./base', './typescript', './import', './esm', 'prettier'],
 };
 
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
Along with our continued focus towards JavaScript Modules (ESM), we want an improved developer experience as well. This pull request adds rules that are ESM goodness!

I still think we have examples where we don't want a few of these rules, so I've kept them grouped in a separate config (esm.js) to make it easier to ignore.

This is considered breaking because we're adding rules that are going to break behaviour on CommonJS projects.